### PR TITLE
fix units for dimensions

### DIFF
--- a/src/api/datasets.ts
+++ b/src/api/datasets.ts
@@ -127,7 +127,7 @@ export async function fetchDatasets() {
 function supabaseDatasetToLegacy(dataset: Camelized<DatasetsFromDb>[number]) {      
     const acq = ensureNotArray(dataset.imageAcquisition)
     const gridSpacing: UnitfulVector = {values: {}, unit: acq.gridSpacingUnit}
-    const dimensions: UnitfulVector = {values: {}, unit: acq.gridSpacingUnit}
+    const dimensions: UnitfulVector = {values: {}, unit: acq.gridDimensionsUnit}
 
     acq.gridAxes?.forEach((axis, idx) => {
         gridSpacing.values[axis] = acq.gridSpacing![idx]

--- a/src/components/AnalysisForm.tsx
+++ b/src/components/AnalysisForm.tsx
@@ -154,7 +154,6 @@ export default function AnalysisForm() {
       setOrganelleB(e.target.value as string);
       // planarity is only for ER-periph contacts with mito & ribo
       const combined = [organelleA, e.target.value].sort().toString();
-      console.log(combined);
       if (
         e.target.value === "" || !combined.match(/^er-periph,(ribo|mito)$/)
       ) {

--- a/src/components/DatasetPaper.tsx
+++ b/src/components/DatasetPaper.tsx
@@ -132,7 +132,6 @@ export default function DatasetPaper({ datasetKey }: DatasetPaperProps) {
 
 	const thumbnailAlt = `2D rendering of ${dataset.name}`;
   const localView = {...views[viewChecked], images: dataset.images.filter(v => imageChecked.has(v.name))} 
-  console.log(localView.images)
   return (
     <Grid container>
       <Grid item md={8}>


### PR DESCRIPTION
This fixes a mistake I made wherein the units for the dimensions of a dataset were not being displayed (the units for the grid spacing was displayed instead). 

I also removed some old uses of `console.log` that weren't needed.