### PR TITLE
chore: drop published filter statement

### DIFF
--- a/src/api/datasets.ts
+++ b/src/api/datasets.ts
@@ -133,7 +133,7 @@ async function queryDatasets(){
                 name,
                 url,
                 type
-            )`).eq('is_published', true).returns<DatasetQueryResult>()
+            )`).returns<DatasetQueryResult>()
   
             if (error === null) {
               return data

--- a/src/api/views.ts
+++ b/src/api/views.ts
@@ -44,7 +44,7 @@ export async function fetchViews() {
             ids
             )
     ),
-      dataset!inner(name)`).eq('dataset.is_published', true).returns<ViewQueryResult>()
+      dataset!inner(name)`).returns<ViewQueryResult>()
     if (error === null) {
       const camelized = camelize(data) as Camelized<typeof data>
       const dateified = stringToDate(camelized) as ToDate<typeof camelized>


### PR DESCRIPTION
the `published` column of the `dataset` table will soon be dropped in favor of a `stage` column. To prepare for that migration, I'm removing the "filter on published" behavior of the dataset and view queries