### PR TITLE
Set neuroglancer view position to the center of a em/lm layer

### DIFF
--- a/src/components/DatasetPaper.tsx
+++ b/src/components/DatasetPaper.tsx
@@ -96,7 +96,7 @@ export default function DatasetPaper({ datasetKey }: DatasetPaperProps) {
       thumbnailUrl: null,
       createdAt: new Date().toDateString(),
       datasetName: dataset.name,
-      position: null,
+      position: dataset.imageAcquisition.gridDimensions.map(arrShape => arrShape / 2),
       scale: null,
       orientation: null,
       taxa: [],


### PR DESCRIPTION
When neuroglancer link is generated by openorganelle, the default `position` variable set to `null`. If only one layer is added, the view position coordinates are at the center of image array. However, when adding several layers to neuroglancer view, the view positions coordinates are set to (0, 0, 0) (top left corner). In order to fix the view position coordinates at the center when multiple layers are present, dataset.imageAcquisition.grid_dimensions (from supabase) are used. 